### PR TITLE
Add stimulus CLI validation and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,10 @@ echo 'PAVLOK_API_KEY=YOUR_API_KEY' > .env
 ```bash
 uv sync
 ```
+
+### 7. コマンド実行例
+刺激の種類と値を指定してAPIへリクエストできます（値は1〜100の範囲に限定されています）。
+
+```bash
+uv run main.py beep 100
+```

--- a/main.py
+++ b/main.py
@@ -7,6 +7,13 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _stimulus_value(value: str) -> int:
+    parsed_value = int(value)
+    if 1 <= parsed_value <= 100:
+        return parsed_value
+    raise argparse.ArgumentTypeError("stimulus_value must be between 1 and 100 (inclusive).")
+
+
 def call(stimulus_type: str, stimulus_value: int):
     url = "https://api.pavlok.com/api/v5/stimulus/send"
     api_key = os.getenv("PAVLOK_API_KEY")
@@ -33,11 +40,20 @@ def main():
     parser = argparse.ArgumentParser(
         description="Send a Pavlok stimulus via the API.",
     )
-    parser.add_argument("stimulusType", help="Type of stimulus to send.")
-    parser.add_argument("stimulusValue", type=int, help="Stimulus value as an integer.")
+    parser.add_argument(
+        "stimulus_type",
+        choices=["vibe", "beep", "zap"],
+        help="Type of stimulus to send (vibe, beep, or zap).",
+    )
+    parser.add_argument(
+        "stimulus_value",
+        type=_stimulus_value,
+        help="Stimulus value as an integer between 1 and 100.",
+        metavar="stimulus_value",
+    )
     args = parser.parse_args()
 
-    call(args.stimulusType, args.stimulusValue)
+    call(args.stimulus_type, args.stimulus_value)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ dependencies = [
   "requests>=2.32.5",
 ]
 
+[tool.hatch.build.targets.wheel]
+# Include the top-level script so editable builds succeed even without a package directory.
+include = ["main.py"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- validate stimulus type options and enforce value range for the CLI arguments
- keep API call behavior while improving input errors
- document a usage example for running the command with uv

## Testing
- `uv run main.py --help`
- `uv run main.py beep 100`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695128d5b578832ea562e9271b9e9036)